### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ gem 'webpacker', git: 'https://github.com/rails/webpacker.git'
 yarn add https://github.com/rails/webpacker.git
 yarn add core-js regenerator-runtime
 ```
+※If you can't execute the command ``yarn add https://github.com/rails/webpacker.git`` , your node version is maybe out of date.
+Expected version "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7".
 
 Finally, run the following to install Webpacker:
 


### PR DESCRIPTION
When node.js's version is <13.7 , we can't use webpacker.(we can't make public/packs in short)
But we upgrade node's version to >=13.7, we can use webpacker。